### PR TITLE
fix: replace deprecated getObject function

### DIFF
--- a/src/entityViewer.ts
+++ b/src/entityViewer.ts
@@ -132,7 +132,7 @@ namespace EntityViewer {
                     ]);
 
 
-                    const rideObject = context.getObject("ride", car.rideObject);
+                    const rideObject = objectManager.getObject("ride", car.rideObject);
                     const vehicleObject = rideObject.vehicles[car.vehicleObject];
 
                     data = data.concat([


### PR DESCRIPTION
Replace `context.getObject(...)` with `objectManager.getObject(...)`.