### PR TITLE
Update type reference and fix spelling of 'separator'

### DIFF
--- a/node_modules/@types/openrct2/index.d.ts
+++ b/node_modules/@types/openrct2/index.d.ts
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2023 OpenRCT2 developers
+ * Copyright (c) 2014-2025 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -56,7 +56,10 @@ declare global {
      * Plugin writers should check if ui is available using `typeof ui !== 'undefined'`.
      */
     var ui: Ui;
-
+    /**
+     * APIs for managing the installed plugins
+     */
+    var pluginManager: PluginManager;
     /**
      * Registers the plugin. This may only be called once.
      * @param metadata Information about the plugin and the entry point.
@@ -112,6 +115,13 @@ declare global {
      */
     interface CoordsXYZD extends CoordsXYZ {
         direction: Direction;
+    }
+
+    /**
+     * A track piece coordinate and type within the game.
+     */
+    interface CarTrackLocation extends Readonly<CoordsXYZD> {
+        readonly trackType: number;
     }
 
     /**
@@ -214,6 +224,11 @@ declare global {
         readonly mode: GameMode;
 
         /**
+         * Whether the game is currently paused or not. Readonly in network mode.
+         */
+        paused: boolean;
+
+        /**
          * Render the current state of the map and save to disc.
          * Useful for server administration and timelapse creation.
          * @param options Options that control the capture and output file.
@@ -309,14 +324,13 @@ declare global {
         queryAction(action: string, args: object, callback?: (result: GameActionResult) => void): void;
         queryAction(action: ActionType, args: object, callback?: (result: GameActionResult) => void): void;
         queryAction(action: "balloonpress", args: BalloonPressArgs, callback?: (result: GameActionResult) => void): void;
-        queryAction(action: "bannerplace", args: BannerPlaceArgs, callback?: (result: GameActionResult) => void): void;
+        queryAction(action: "bannerplace", args: BannerPlaceArgs, callback?: (result: BannerCreateActionResult) => void): void;
         queryAction(action: "bannerremove", args: BannerRemoveArgs, callback?: (result: GameActionResult) => void): void;
         queryAction(action: "bannersetcolour", args: BannerSetColourArgs, callback?: (result: GameActionResult) => void): void;
         queryAction(action: "bannersetname", args: BannerSetNameArgs, callback?: (result: GameActionResult) => void): void;
         queryAction(action: "bannersetstyle", args: BannerSetStyleArgs, callback?: (result: GameActionResult) => void): void;
         queryAction(action: "cheatset", args: CheatSetArgs, callback?: (result: GameActionResult) => void): void;
         queryAction(action: "clearscenery", args: ClearSceneryArgs, callback?: (result: GameActionResult) => void): void;
-        queryAction(action: "climateset", args: ClimateSetArgs, callback?: (result: GameActionResult) => void): void;
         queryAction(action: "footpathadditionplace", args: FootpathAdditionPlaceArgs, callback?: (result: GameActionResult) => void): void;
         queryAction(action: "footpathadditionremove", args: FootpathAdditionRemoveArgs, callback?: (result: GameActionResult) => void): void;
         queryAction(action: "footpathplace", args: FootpathPlaceArgs, callback?: (result: GameActionResult) => void): void;
@@ -331,7 +345,7 @@ declare global {
         queryAction(action: "landsetheight", args: LandSetHeightArgs, callback?: (result: GameActionResult) => void): void;
         queryAction(action: "landsetrights", args: LandSetRightsArgs, callback?: (result: GameActionResult) => void): void;
         queryAction(action: "landsmooth", args: LandSmoothArgs, callback?: (result: GameActionResult) => void): void;
-        queryAction(action: "largesceneryplace", args: LargeSceneryPlaceArgs, callback?: (result: GameActionResult) => void): void;
+        queryAction(action: "largesceneryplace", args: LargeSceneryPlaceArgs, callback?: (result: BannerCreateActionResult) => void): void;
         queryAction(action: "largesceneryremove", args: LargeSceneryRemoveArgs, callback?: (result: GameActionResult) => void): void;
         queryAction(action: "largescenerysetcolour", args: LargeScenerySetColourArgs, callback?: (result: GameActionResult) => void): void;
         queryAction(action: "loadorquit", args: LoadOrQuitArgs, callback?: (result: GameActionResult) => void): void;
@@ -384,7 +398,7 @@ declare global {
         queryAction(action: "trackplace", args: TrackPlaceArgs, callback?: (result: GameActionResult) => void): void;
         queryAction(action: "trackremove", args: TrackRemoveArgs, callback?: (result: GameActionResult) => void): void;
         queryAction(action: "tracksetbrakespeed", args: TrackSetBrakeSpeedArgs, callback?: (result: GameActionResult) => void): void;
-        queryAction(action: "wallplace", args: WallPlaceArgs, callback?: (result: GameActionResult) => void): void;
+        queryAction(action: "wallplace", args: WallPlaceArgs, callback?: (result: BannerCreateActionResult) => void): void;
         queryAction(action: "wallremove", args: WallRemoveArgs, callback?: (result: GameActionResult) => void): void;
         queryAction(action: "wallsetcolour", args: WallSetColourArgs, callback?: (result: GameActionResult) => void): void;
         queryAction(action: "waterlower", args: WaterLowerArgs, callback?: (result: GameActionResult) => void): void;
@@ -401,14 +415,13 @@ declare global {
         executeAction(action: string, args: object, callback?: (result: GameActionResult) => void): void;
         executeAction(action: ActionType, args: object, callback?: (result: GameActionResult) => void): void;
         executeAction(action: "balloonpress", args: BalloonPressArgs, callback?: (result: GameActionResult) => void): void;
-        executeAction(action: "bannerplace", args: BannerPlaceArgs, callback?: (result: GameActionResult) => void): void;
+        executeAction(action: "bannerplace", args: BannerPlaceArgs, callback?: (result: BannerCreateActionResult) => void): void;
         executeAction(action: "bannerremove", args: BannerRemoveArgs, callback?: (result: GameActionResult) => void): void;
         executeAction(action: "bannersetcolour", args: BannerSetColourArgs, callback?: (result: GameActionResult) => void): void;
         executeAction(action: "bannersetname", args: BannerSetNameArgs, callback?: (result: GameActionResult) => void): void;
         executeAction(action: "bannersetstyle", args: BannerSetStyleArgs, callback?: (result: GameActionResult) => void): void;
         executeAction(action: "cheatset", args: CheatSetArgs, callback?: (result: GameActionResult) => void): void;
         executeAction(action: "clearscenery", args: ClearSceneryArgs, callback?: (result: GameActionResult) => void): void;
-        executeAction(action: "climateset", args: ClimateSetArgs, callback?: (result: GameActionResult) => void): void;
         executeAction(action: "footpathadditionplace", args: FootpathAdditionPlaceArgs, callback?: (result: GameActionResult) => void): void;
         executeAction(action: "footpathadditionremove", args: FootpathAdditionRemoveArgs, callback?: (result: GameActionResult) => void): void;
         executeAction(action: "footpathplace", args: FootpathPlaceArgs, callback?: (result: GameActionResult) => void): void;
@@ -423,7 +436,7 @@ declare global {
         executeAction(action: "landsetheight", args: LandSetHeightArgs, callback?: (result: GameActionResult) => void): void;
         executeAction(action: "landsetrights", args: LandSetRightsArgs, callback?: (result: GameActionResult) => void): void;
         executeAction(action: "landsmooth", args: LandSmoothArgs, callback?: (result: GameActionResult) => void): void;
-        executeAction(action: "largesceneryplace", args: LargeSceneryPlaceArgs, callback?: (result: GameActionResult) => void): void;
+        executeAction(action: "largesceneryplace", args: LargeSceneryPlaceArgs, callback?: (result: BannerCreateActionResult) => void): void;
         executeAction(action: "largesceneryremove", args: LargeSceneryRemoveArgs, callback?: (result: GameActionResult) => void): void;
         executeAction(action: "largescenerysetcolour", args: LargeScenerySetColourArgs, callback?: (result: GameActionResult) => void): void;
         executeAction(action: "loadorquit", args: LoadOrQuitArgs, callback?: (result: GameActionResult) => void): void;
@@ -476,7 +489,7 @@ declare global {
         executeAction(action: "trackplace", args: TrackPlaceArgs, callback?: (result: GameActionResult) => void): void;
         executeAction(action: "trackremove", args: TrackRemoveArgs, callback?: (result: GameActionResult) => void): void;
         executeAction(action: "tracksetbrakespeed", args: TrackSetBrakeSpeedArgs, callback?: (result: GameActionResult) => void): void;
-        executeAction(action: "wallplace", args: WallPlaceArgs, callback?: (result: GameActionResult) => void): void;
+        executeAction(action: "wallplace", args: WallPlaceArgs, callback?: (result: BannerCreateActionResult) => void): void;
         executeAction(action: "wallremove", args: WallRemoveArgs, callback?: (result: GameActionResult) => void): void;
         executeAction(action: "wallsetcolour", args: WallSetColourArgs, callback?: (result: GameActionResult) => void): void;
         executeAction(action: "waterlower", args: WaterLowerArgs, callback?: (result: GameActionResult) => void): void;
@@ -488,20 +501,21 @@ declare global {
          */
         subscribe(hook: HookType, callback: Function): IDisposable;
 
-        subscribe(hook: "action.query", callback: (e: GameActionEventArgs) => void): IDisposable;
         subscribe(hook: "action.execute", callback: (e: GameActionEventArgs) => void): IDisposable;
-        subscribe(hook: "interval.tick", callback: () => void): IDisposable;
+        subscribe(hook: "action.location", callback: (e: ActionLocationArgs) => void): IDisposable;
+        subscribe(hook: "action.query", callback: (e: GameActionEventArgs) => void): IDisposable;
+        subscribe(hook: "guest.generation", callback: (e: GuestGenerationArgs) => void): IDisposable;
         subscribe(hook: "interval.day", callback: () => void): IDisposable;
-        subscribe(hook: "network.chat", callback: (e: NetworkChatEventArgs) => void): IDisposable;
+        subscribe(hook: "interval.tick", callback: () => void): IDisposable;
+        subscribe(hook: "map.change", callback: () => void): IDisposable;
+        subscribe(hook: "map.save", callback: () => void): IDisposable;
         subscribe(hook: "network.authenticate", callback: (e: NetworkAuthenticateEventArgs) => void): IDisposable;
+        subscribe(hook: "network.chat", callback: (e: NetworkChatEventArgs) => void): IDisposable;
         subscribe(hook: "network.join", callback: (e: NetworkEventArgs) => void): IDisposable;
         subscribe(hook: "network.leave", callback: (e: NetworkEventArgs) => void): IDisposable;
+        subscribe(hook: "park.guest.softcap.calculate", callback: (e: ParkCalculateGuestCapArgs) => void): IDisposable;
         subscribe(hook: "ride.ratings.calculate", callback: (e: RideRatingsCalculateArgs) => void): IDisposable;
-        subscribe(hook: "action.location", callback: (e: ActionLocationArgs) => void): IDisposable;
-        subscribe(hook: "guest.generation", callback: (e: GuestGenerationArgs) => void): IDisposable;
         subscribe(hook: "vehicle.crash", callback: (e: VehicleCrashArgs) => void): IDisposable;
-        subscribe(hook: "map.save", callback: () => void): IDisposable;
-        subscribe(hook: "map.change", callback: () => void): IDisposable;
 
         /**
          * Can only be used in intransient plugins.
@@ -604,18 +618,35 @@ declare global {
         "scenery_group" |
         "park_entrance" |
         "water" |
+        "scenario_text" |
         "terrain_surface" |
         "terrain_edge" |
         "station" |
         "music" |
         "footpath_surface" |
-        "footpath_railings";
+        "footpath_railings" |
+        "audio" |
+        "peep_names" |
+        "peep_animations" |
+        "climate";
 
     type HookType =
-        "interval.tick" | "interval.day" |
-        "network.chat" | "network.action" | "network.join" | "network.leave" |
-        "ride.ratings.calculate" | "action.location" | "vehicle.crash" |
-        "map.change" | "map.changed" | "map.save";
+        "action.execute" |
+        "action.location" |
+        "action.query" |
+        "guest.generation" |
+        "interval.day" |
+        "interval.tick" |
+        "map.change" |
+        "map.changed" |
+        "map.save" |
+        "network.authenticate" |
+        "network.chat" |
+        "network.join" |
+        "network.leave" |
+        "park.guest.softcap.calculate" |
+        "ride.ratings.calculate" |
+        "vehicle.crash";
 
     type ExpenditureType =
         "ride_construction" |
@@ -642,7 +673,6 @@ declare global {
         "bannersetstyle" |
         "cheatset" |
         "clearscenery" |
-        "climateset" |
         "footpathadditionplace" |
         "footpathadditionremove" |
         "footpathplace" |
@@ -719,7 +749,8 @@ declare global {
 
 
     interface GameActionArgs {
-        flags?: number; // see GAME_COMMAND in openrct2/Game.h
+        /** @see `GameCommand` in {@link https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/Game.h} */
+        flags?: number;
     }
 
     interface BalloonPressArgs extends GameActionArgs {
@@ -757,22 +788,38 @@ declare global {
 
     interface BannerSetStyleArgs extends GameActionArgs {
         id: number;
-        type: number; // 0: primary colour, 1: secondary colour: 2: no entry
-        parameter: number; // primary colour | secondary colour | 0: disable, 1: enable
+        /**
+         * `0`: Primary colour
+         * `1`: Secondary colour
+         * `2`: No entry
+         */
+        type: number;
+        /**
+         * If {@link BannerSetStyleArgs.type} === 0 (primary), or === 1 (secondary):
+         * - `0`: Disable
+         * - `1`: Enable
+         */
+        parameter: number;
     }
 
     interface CheatSetArgs extends GameActionArgs {
-        type: number; // see CheatType in openrct2/Cheats.h
-        param1: number; // see openrct2/actions/CheatSetAction.cpp
-        param2: number; // see openrct2/actions/CheatSetAction.cpp
+        /** @see {@link https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/Cheats.h} */
+        type: number;
+        /** @see {@link https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/actions/CheatSetAction.h} */
+        param1: number;
+        /** @see {@link https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/actions/CheatSetAction.h} */
+        param2: number;
     }
 
     interface ClearSceneryArgs extends GameActionArgs {
-        itemsToClear: number; // Bit mask. 1: small scenery and walls, 2: large scenery, 4: footpaths.
-    }
-
-    interface ClimateSetArgs extends GameActionArgs {
-        climate: number; // 0: cool and wet, 1: warm, 2: hot and dry, 3: cold
+        /**
+         * Bitmask.
+         *
+         * - `1`: `(001)`: Small scenery and walls
+         * - `2`: `(010)`: Large scenery
+         * - `4`: `(100)`: Footpaths
+         */
+        itemsToClear: number;
     }
 
     interface FootpathAdditionPlaceArgs extends GameActionArgs {
@@ -792,22 +839,35 @@ declare global {
         x: number;
         y: number;
         z: number;
-        direction: number; // direction or 0xFF
-        object: number; // surface object
+        /** Direction or `0xFF` */
+        direction: number;
+        /** Surface object */
+        object: number;
         railingsObject: number;
-        slope: number; // 0: flat, 4,5,6,7: slope direction + 4
+        /**
+         * - `0`: Flat
+         * - `4`, `5`, `6`, `7`: Slope direction + 4
+         */
+        slope: number;
         constructFlags: number;
     }
 
-    // see openrct2/actions/FootpathPlaceFromTrackAction
+    /**
+     * @see {@link https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/actions/FootpathPlaceAction.h}
+     */
     interface FootpathLayoutPlaceArgs extends GameActionArgs {
         x: number;
         y: number;
         z: number;
-        edges: number; // bit mask
+        /** Bitmask */
+        edges: number;
         object: number;
         railingsObject: number;
-        slope: number; // 0: flat, 4,5,6,7: slope direction + 4
+        /**
+         * - `0`: Flat
+         * - `4`, `5`, `6`, `7`: Slope direction + 4
+         */
+        slope: number;
         constructFlags: number;
     }
 
@@ -821,10 +881,12 @@ declare global {
         speed: number;
     }
 
-    // recommendation: use Peep.setFlag instead of the GuestSetFlag action
     interface GuestSetFlagsArgs extends GameActionArgs {
         peep: number;
-        guestFlags: number; // see PEEP_FLAGS in openrct2/entity/Peep.h
+        /**
+         * @see `PEEP_FLAGS` in {@link https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/entity/Peep.h}
+         */
+        guestFlags: number;
     }
 
     interface GuestSetNameArgs extends GameActionArgs {
@@ -837,11 +899,17 @@ declare global {
         y1: number;
         x2: number;
         y2: number;
-        setting: number; // 0: buy land, 1: buy construction rights
+        /**
+         * - `0`: Buy land
+         * - `1`: Buy construction rights
+         */
+        setting: number;
     }
 
-    // x, y specify the centre. Only used for GameActionResult and 3D audio position.
-    // x1, y1, x2, y2 specify a map range
+    /**
+     * x, y specify the centre. Only used for {@link GameActionResult} and 3D audio position.
+     * x1, y1, x2, y2 specify a map range
+     */
     interface LandLowerArgs extends GameActionArgs {
         x: number;
         y: number;
@@ -849,11 +917,14 @@ declare global {
         y1: number;
         x2: number;
         y2: number;
-        selectionType: number; // see MAP_SELECT_TYPE in openrct2/world/Map.h
+        /** @see `MAP_SELECT_TYPE` in {@link https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/world/Map.h} */
+        selectionType: number;
     }
 
-    // x, y specify the centre. Only used for GameActionResult and 3D audio position.
-    // x1, y1, x2, y2 specify a map range
+    /**
+     * x, y specify the centre. Only used for {@link GameActionResult} and 3D audio position.
+     * x1, y1, x2, y2 specify a map range
+     */
     interface LandRaiseArgs extends GameActionArgs {
         x: number;
         y: number;
@@ -861,14 +932,16 @@ declare global {
         y1: number;
         x2: number;
         y2: number;
-        selectionType: number; // see MAP_SELECT_TYPE in openrct2/world/Map.h
+        /** @see `MAP_SELECT_TYPE` in {@link https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/world/Map.h} */
+        selectionType: number;
     }
 
     interface LandSetHeightArgs extends GameActionArgs {
         x: number;
         y: number;
         height: number;
-        style: number; // see TILE_ELEMENT_SLOPE in openrct2/world/Surface.h
+        /** @see {@link https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/actions/LandSetHeightAction.h} */
+        style: number;
     }
 
     interface LandSetRightsArgs extends GameActionArgs {
@@ -876,12 +949,26 @@ declare global {
         y1: number;
         x2: number;
         y2: number;
-        setting: number; // 0: unown land, 1: unown construction rights, 2: set for sale, 3: set construction rights for sale, 4: set ownership
-        ownership: number; // only used if setting = 4 (set ownership). See OWNERSHIP in openrct2/world/Surface.h
+        /**
+         * - `0`: Unown land
+         * - `1`: Unown construction rights
+         * - `2`: Set for sale
+         * - `3`: Set construction rights for sale
+         * - `4`: Set ownership
+         */
+        setting: number;
+        /**
+         * Only used if {@link LandSetRightsArgs.setting} === 4 (set ownership)
+         *
+         * @see {@link https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/world/tile_element/SurfaceElement.h}
+         */
+        ownership: number;
     }
 
-    // x, y specify the centre. Only used for GameActionResult and 3D audio position.
-    // x1, y1, x2, y2 specify a map range
+    /**
+     * x, y specify the centre. Only used for {@link GameActionResult} and 3D audio position.
+     * x1, y1, x2, y2 specify a map range
+     */
     interface LandSmoothArgs extends GameActionArgs {
         x: number;
         y: number;
@@ -889,7 +976,10 @@ declare global {
         y1: number;
         x2: number;
         y2: number;
-        selectionType: number; // see MAP_SELECT_TYPE in openrct2/world/Map.h
+        /**
+         * @see `MAP_SELECT_TYPE` in {@link https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/world/Map.h}
+         */
+        selectionType: number;
         isLowering: boolean;
     }
 
@@ -924,13 +1014,25 @@ declare global {
     }
 
     interface LoadOrQuitArgs extends GameActionArgs {
-        mode: number; // 0: open save prompt, 1: close save prompt
-        savePromptMode: number; // 0: save before load, 1: save before quit. Only used if mode = 0 (open save prompt).
+        /**
+         * - `0`: Open save prompt
+         * - `1`: Close save prompt
+         */
+        mode: number;
+        /**
+         * - `0`: Save before load
+         * - `1`: Save before quit
+         *
+         * Only used if {@link LoadOrQuitArgs.mode} === 0 (open save prompt)
+         */
+        savePromptMode: number;
     }
 
     interface MapChangeSizeArgs extends GameActionArgs {
         targetSizeX: number;
         targetSizeY: number;
+        shiftX: number;
+        shiftY: number;
     }
 
     interface MazePlaceTrackArgs extends GameActionArgs {
@@ -947,16 +1049,46 @@ declare global {
         z: number;
         direction: number;
         ride: number;
-        mode: number; // 0: build, 1: move, 2: fill
+        /**
+         * - `0`: Build
+         * - `1`: Move
+         * - `2`: Fill
+         */
+        mode: number;
         isInitialPlacement: boolean;
     }
 
     interface NetworkModifyGroupArgs extends GameActionArgs {
-        type: number; // 0: add group, 1: remove group, 2: set permissions, 3: set name, 4: set default
-        groupId: number; // ignored if type = 0 (add group)
-        name: string; // only used if type = 3 (set name)
-        permissionIndex: number; // only used if type = 2 (set permissions). See NetworkPermission in openrct2/network/NetworkAction.h
-        permissionState: number; // only used if type = 2 (set permissions). 0: toggle, 1: set all, 2: clear all
+        /**
+         * - `0`: Add group
+         * - `1`: Remove group
+         * - `2`: Set permissions
+         * - `3`: Set name
+         * - `4`: Set default
+         */
+        type: number;
+        /**
+         * Ignored if {@link NetworkModifyGroupArgs.type} === 0 (add group)
+         */
+        groupId: number;
+        /**
+         * Only used if {@link NetworkModifyGroupArgs.type} === 3 (set name)
+         */
+        name: string;
+        /**
+         * Only used if {@link NetworkModifyGroupArgs.type} === 2 (set permissions)
+         *
+         * @see `NetworkPermission` in {@link https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/network/NetworkAction.h}
+         */
+        permissionIndex: number;
+        /**
+         * - `0`: Toggle
+         * - `1`: Set all
+         * - `2`: Clear all
+         *
+         * Only used if {@link NetworkModifyGroupArgs.type} === 2 (set permissions)
+         */
+        permissionState: number;
     }
 
     interface ParkEntrancePlaceArgs extends GameActionArgs {
@@ -974,8 +1106,15 @@ declare global {
     }
 
     interface ParkMarketingArgs extends GameActionArgs {
-        type: number; // see ADVERTISING_CAMPAIGN in openrct2/management/Marketing.h
-        item: number; // ride id or shop item. See ShopItem in openrct2/ride/ShopItem.h
+        /**
+         * @see `ADVERTISTING_CAMPAIGN` in {@link https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/management/Marketing.h}
+         */
+        type: number;
+        /**
+         * Ride ID or Shop Item
+         * @see `ShopItem` in {@link https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/ride/ShopItem.h}
+         */
+        item: number;
         numweeks: number;
     }
 
@@ -998,25 +1137,63 @@ declare global {
     }
 
     interface ParkSetParameterArgs extends GameActionArgs {
-        parameter: number; // 0: close park, 1: open park, 2: set same price in park
-        value: number; // only used if parameter = 2 (set same price in park). Bit mask. See ShopItem in openrct2/ride/ShopItem.h
+        /**
+         * - `0`: Close park
+         * - `1`: Open park
+         * - `2`: Set same price in park
+         */
+        parameter: number;
+        /**
+         * Only used if {@link ParkSetParameterArgs.parameter} === 2 (set same price in park). Bitmask.
+         *
+         * @see `ShopItem` in {@link https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/ride/ShopItem.h}
+         */
+        value: number;
     }
 
     interface ParkSetResearchFundingArgs extends GameActionArgs {
-        priorities: number; // bit mask. See ResearchCategory in openrct2/management/Research.h
-        fundingAmount: number; // 0: none, 1: minimal, 2: normal, 3: maximum
+        /**
+         * Bitmask.
+         *
+         * @see `ResearchCategory` in {@link https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/management/Research.h}
+         */
+        priorities: number;
+        /**
+         * - `0`: None
+         * - `1`: Minimal
+         * - `2`: Normal
+         * - `3`: Maximum
+         */
+        fundingAmount: number;
     }
 
     interface PauseToggleArgs extends GameActionArgs {
     }
 
     interface PeepPickupArgs extends GameActionArgs {
-        type: number; // 0: pickup, 1: cancel, 2: place
+        /**
+         * - `0`: Pickup
+         * - `1`: Cancel
+         * - `3`: Place
+         */
+        type: number;
         id: number;
-        x: number; // unused if type = 0. If type = 1 (cancel), this needs to be the peep's x position BEFORE pickup
-        y: number; // only used if type = 2 (place)
-        z: number; // only used if type = 2 (place)
-        playerId: number; // 0 in single player
+        /**
+         * Unused if {@link PeepPickupArgs.type} === 0.
+         *
+         * If {@link PeepPickupArgs.type} === 1 (cancel), this needs to be the peep's x position BEFORE pickup.
+         */
+        x: number;
+        /**
+         * Only used if {@link PeepPickupArgs.type} === 2 (place)
+         */
+        y: number;
+        /**
+         * Only used if {@link PeepPickupArgs.type} === 2 (place)
+         */
+        z: number;
+        /** `0` in single player */
+        playerId: number;
     }
 
     interface PeepSpawnPlaceArgs extends GameActionArgs {
@@ -1045,7 +1222,11 @@ declare global {
 
     interface RideDemolishArgs extends GameActionArgs {
         ride: number;
-        modifyType: number; // 0: demolish, 1: renew
+        /**
+         * - `0`: Demolish
+         * - `1`: Renew
+         */
+        modifyType: number;
     }
 
     interface RideEntranceExitPlaceArgs extends GameActionArgs {
@@ -1067,20 +1248,39 @@ declare global {
 
     interface RideFreezeRatingArgs extends GameActionArgs {
         ride: number;
-        type: number; // 0: excitement, 1: intensity, 2: nausea
+        /**
+         * - `0`: Excitement
+         * - `1`: Intensity
+         * - `2`: Nausea
+         */
+        type: number;
         value: number;
     }
 
     interface RideSetAppearanceArgs extends GameActionArgs {
         ride: number;
-        type: number; // see RideSetAppearanceType in openrct2/actions/RideSetAppearanceAction.h
-        // value:
-        // - if type is one of the track or vehicle colours: colour
-        // - if type is VehicleColourScheme: 0: all same, 1: per train, 2: per car
-        // - if type is EntranceStyle: entrance style
-        // - if type is SellingItemColourIsRandom: 0: disabled, 1: enabled
+        /**
+         * @see RideSetAppearanceType in
+         * {@link https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/actions/RideSetAppearanceAction.h}
+         */
+        type: number;
+        /**
+         * If {@link RideSetAppearanceArgs.type} is:
+         * - One of the track or vehicle colours: Colour
+         * - VehicleColourScheme:
+         *   - `0`: All same
+         *   - `1`: Per train
+         *   - `2`: Per car
+         * - EntranceStyle: Entrance style
+         * - SellingItemColourIsRandom:
+         *   - `0`: Disabled
+         *   - `1`: Enabled
+         */
         value: number;
-        index: number; // colour scheme index, only used if type is one of the track or vehicle colours
+        /**
+         * Color scheme index, only used if {@link RideSetAppearanceArgs.type} is one of the track or vehicle colours
+         */
+        index: number;
     }
 
     interface RideSetColourSchemeArgs extends GameActionArgs {
@@ -1105,24 +1305,47 @@ declare global {
 
     interface RideSetSettingArgs extends GameActionArgs {
         ride: number;
-        setting: number; // see RideSetSetting in openrct2/actions/RideSetSettingAction.h
+        /**
+         * @see `RideSetSetting` in {@link https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/actions/RideSetSettingAction.h}
+         */
+        setting: number;
         value: number;
     }
 
     interface RideSetStatusArgs extends GameActionArgs {
         ride: number;
-        status: number; // 0: closed, 1: open, 2: testing, 3: simulating
+        /**
+         * - `0`: Closed
+         * - `1`: Open
+         * - `2`: Testing
+         * - `3`: Simulating
+         */
+        status: number;
     }
 
     interface RideSetVehicleArgs extends GameActionArgs {
         ride: number;
-        type: number; // 0: number of trains, 1: number of cars per train, 2: ride entry
-        value: number; // number value or sub type
-        colour: number; // only used if type is ride entry
+        /**
+         * - `0`: Number of trains
+         * - `1`: Number of cars per train
+         * - `2`: Ride entry
+         */
+        type: number;
+        /**
+         * Number value or subtype of {@link RideSetVehicleArgs.type}
+         */
+        value: number;
+        /**
+         * Only used if {@link RideSetVehicleArgs.type} === 2 (ride entry)
+         */
+        colour: number;
     }
 
     interface ScenarioSetSettingArgs extends GameActionArgs {
-        setting: number; // see ScenarioSetSetting in openrct2/actions/ScenarioSetSettingAction.h
+        /**
+         * @see ScenarioSetSetting in {@link https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/actions/ScenarioSetSettingAction.h}
+         */
+        setting: number;
         value: number;
     }
 
@@ -1147,6 +1370,7 @@ declare global {
         quadrant: number;
         primaryColour: number;
         secondaryColour: number;
+        tertiaryColour: number;
     }
 
     interface SmallSceneryRemoveArgs extends GameActionArgs {
@@ -1174,19 +1398,46 @@ declare global {
 
     interface StaffHireArgs extends GameActionArgs {
         autoPosition: boolean;
-        staffType: number; // 0: handyman, 1: mechanic, 2: security, 3: entertainer
-        entertainerType: number; // see EntertainerCostume in openrct2/entity/Staff.h
-        staffOrders: number; // bit mask. See STAFF_ORDERS in openrct2/entity/Staff.h
+        /**
+         * - `0`: Handyman
+         * - `1`: Mechanic
+         * - `2`: Security
+         * - `3`: Entertainer
+         */
+        staffType: number;
+        /** Peep animation object ID to use as costume */
+        costumeIndex: number;
+        /**
+         * Bitmask. Only applies when {@link StaffHireArgs.staffType} === 0 (Handyman), or === 1 (Mechanic).
+         *
+         * Handyman:
+         * - `1`: `(0001)`: Sweeping
+         * - `2`: `(0010)`: Watering flowers
+         * - `4`: `(0100)`: Empty bins
+         * - `8`: `(1000)`: Mowing
+         *
+         * Mechanic:
+         * - `1`: `(0001)`: Inspect rides
+         * - `2`: `(0010)`: Fix rides
+         */
+        staffOrders: number;
     }
 
     interface StaffSetColourArgs extends GameActionArgs {
-        staffType: number; // 0: handyman, 1: mechanic, 2: security, 3: entertainer
+        /**
+         * - `0`: Handyman
+         * - `1`: Mechanic
+         * - `2`: Security
+         * - `3`: Entertainer
+         */
+        staffType: number;
         colour: number;
     }
 
     interface StaffSetCostumeArgs extends GameActionArgs {
         id: number;
-        costume: number; // see EntertainerCostume in openrct2/entity/Staff.h
+        /** @see `EntertainerCostume` in {@link https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/entity/Staff.h} */
+        costume: number;
     }
 
     interface StaffSetNameArgs extends GameActionArgs {
@@ -1196,7 +1447,20 @@ declare global {
 
     interface StaffSetOrdersArgs extends GameActionArgs {
         id: number;
-        staffOrders: number; // bit mask. See STAFF_ORDERS in openrct2/entity/Staff.h
+        /**
+         * Bitmask. Only applies when {@link StaffHireArgs.staffType} === 0 (Handyman), or === 1 (Mechanic).
+         *
+         * Handyman:
+         * - `1`: `(0001)`: Sweeping
+         * - `2`: `(0010)`: Watering flowers
+         * - `4`: `(0100)`: Empty bins
+         * - `8`: `(1000)`: Mowing
+         *
+         * Mechanic:
+         * - `1`: `(0001)`: Inspect rides
+         * - `2`: `(0010)`: Fix rides
+         */
+        staffOrders: number;
     }
 
     interface StaffSetPatrolAreaArgs extends GameActionArgs {
@@ -1205,7 +1469,12 @@ declare global {
         y1: number;
         x2: number;
         y2: number;
-        mode: number; // 0: set, 1: unset, 2: clear all
+        /**
+         * - `0`: Set
+         * - `1`: Unset
+         * - `2`: Clear all
+         */
+        mode: number;
     }
 
     interface SurfaceSetStyleArgs extends GameActionArgs {
@@ -1217,16 +1486,28 @@ declare global {
         edgeStyle: number;
     }
 
-    // does not support TileModifyType::AnyPaste
+    /**
+     * @todo Does not support `TileModifyType::AnyPaste`
+     */
     interface TileModifyArgs extends GameActionArgs {
         x: number;
         y: number;
-        setting: number; // see TileModifyType in openrct2/actions/TileModifyAction.h
+        /**
+         * @see `TileModifyType` in
+         * {@link https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/actions/TileModifyAction.h}
+         */
+        setting: number;
         value1: number;
-        value2: number; // see openrct2/actions/TileModifyAction.cpp
+        /**
+         * @see TileModifyType in
+         * {@link https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/actions/TileModifyAction.cpp}
+         */
+        value2: number;
     }
 
-    // currently unsupported
+    /**
+     * @todo Currently unsupported
+     */
     interface TrackDesignArgs extends GameActionArgs {
         x: number;
         y: number;
@@ -1271,7 +1552,8 @@ declare global {
         y: number;
         z: number;
         object: number;
-        edge: number; // = direction
+        /** Direction */
+        edge: number;
         primaryColour: number;
         secondaryColour: number;
         tertiaryColour: number;
@@ -1332,6 +1614,10 @@ declare global {
         expenditureType?: ExpenditureType;
     }
 
+    interface BannerCreateActionResult extends GameActionResult {
+        readonly bannerIndex?: number;
+    }
+
     interface RideCreateActionResult extends GameActionResult {
         readonly ride?: number;
     }
@@ -1383,6 +1669,14 @@ declare global {
     }
 
     /**
+     * The 'suggestedGuestMaximum' field in this interface can be used to override
+     * the park's suggested guest cap.
+     */
+    interface ParkCalculateGuestCapArgs {
+        suggestedGuestMaximum: number;
+    }
+
+    /**
      * APIs for the in-game date.
      */
     interface GameDate {
@@ -1416,6 +1710,7 @@ declare global {
         readonly year: number;
     }
 
+
     /**
      * APIs for the map.
      */
@@ -1437,11 +1732,15 @@ declare global {
         getAllEntities(type: "staff"): Staff[];
         getAllEntities(type: "car"): Car[];
         getAllEntities(type: "litter"): Litter[];
+        getAllEntities(type: "balloon"): Balloon[];
+        getAllEntities(type: "money_effect"): MoneyEffect[];
         getAllEntitiesOnTile(type: EntityType, tilePos: CoordsXY): Entity[];
         getAllEntitiesOnTile(type: "guest", tilePos: CoordsXY): Guest[];
         getAllEntitiesOnTile(type: "staff", tilePos: CoordsXY): Staff[];
         getAllEntitiesOnTile(type: "car", tilePos: CoordsXY): Car[];
         getAllEntitiesOnTile(type: "litter", tilePos: CoordsXY): Litter[];
+        getAllEntitiesOnTile(type: "balloon", tilePos: CoordsXY): Balloon[];
+        getAllEntitiesOnTile(type: "money_effect", tilePos: CoordsXY): MoneyEffect[];
         createEntity(type: EntityType, initializer: object): Entity;
 
         /**
@@ -1451,6 +1750,7 @@ declare global {
          * @param elementIndex The index of the track element on the tile.
          */
         getTrackIterator(location: CoordsXY, elementIndex: number): TrackIterator | null;
+
     }
 
     type TileElementType =
@@ -1471,8 +1771,12 @@ declare global {
         clearanceZ: number;
         occupiedQuadrants: number;
         isGhost: boolean;
-        isHidden: boolean; /** Take caution when changing this field, it may invalidate TileElements you have stored in your script. */
-        owner: number;
+        /**
+         * Take caution when changing this field, it may invalidate TileElements you have stored in your script.
+         *
+         * @todo Need to validate if this comment still accurately describes behavior in latest OpenRCT2
+         * */
+        isHidden: boolean;
     }
 
     interface SurfaceElement extends BaseTileElement {
@@ -1493,18 +1797,21 @@ declare global {
     interface FootpathElement extends BaseTileElement {
         type: "footpath";
 
-        object: number | null; /** Legacy footpaths, still in use. */
-        surfaceObject: number | null; /** NSF footpaths */
-        railingsObject: number | null; /** NSF footpaths */
+        /** Legacy footpaths, still in use. */
+        object: number | null;
+        /** NSF footpaths */
+        surfaceObject: number | null;
+        /** NSF footpaths */
+        railingsObject: number | null;
 
         edges: number;
         corners: number;
-        slopeDirection: number | null;
+        slopeDirection: Direction | null;
         isBlockedByVehicle: boolean;
         isWide: boolean;
 
         isQueue: boolean;
-        queueBannerDirection: number | null;
+        queueBannerDirection: Direction | null;
         ride: number | null;
         station: number | null;
 
@@ -1543,6 +1850,7 @@ declare global {
         object: number;
         primaryColour: number;
         secondaryColour: number;
+        tertiaryColour: number;
         quadrant: number;
         age: number;
     }
@@ -1553,10 +1861,14 @@ declare global {
         direction: Direction;
         object: number;
         primaryColour: number;
+        /** If the element is a banner, this is the text colour. */
         secondaryColour: number;
         tertiaryColour: number;
-        bannerIndex: number | null;
         slope: Direction;
+        /** Writing to bannerIndex is deprecated and may result in uncontrolled behaviour. */
+        readonly bannerIndex: number | null;
+        /** If the element is a banner, this is its text. */
+        bannerText: string | null;
     }
 
     interface EntranceElement extends BaseTileElement {
@@ -1577,16 +1889,28 @@ declare global {
         direction: Direction;
         object: number;
         primaryColour: number;
+        /** If the element is a banner, this is the text colour. */
         secondaryColour: number;
         tertiaryColour: number;
-        bannerIndex: number | null;
         sequence: number;
+        /** Writing to bannerIndex is deprecated and may result in uncontrolled behaviour. */
+        readonly bannerIndex: number | null;
+        /** If the element is a banner, this is its text. */
+        bannerText: string | null;
     }
 
     interface BannerElement extends BaseTileElement {
         type: "banner";
+
         direction: Direction;
-        bannerIndex: number;
+        object: number;
+        primaryColour: number;
+        /** This is the text colour. */
+        secondaryColour: number;
+        /** Writing to bannerIndex is deprecated and may result in uncontrolled behaviour. */
+        readonly bannerIndex: number;
+        bannerText: string;
+        isNoEntry: boolean;
     }
 
     /**
@@ -1723,8 +2047,8 @@ declare global {
     }
 
     /**
-    * Represents the definition of a loaded object that has one or more associated images.
-    */
+     * Represents the definition of a loaded object that has one or more associated images.
+     */
     interface LoadedImageObject extends LoadedObject {
         /**
          * Id of the objects base image. This is also known as the preview image.
@@ -1891,6 +2215,39 @@ declare global {
 
     interface LargeSceneryObject extends SceneryObject {
 
+        readonly tiles: LargeSceneryObjectTile[];
+    }
+
+    interface LargeSceneryObjectTile {
+        /**
+         * The offset from tile index 0's location to this tile
+         */
+        readonly offset: CoordsXYZ;
+
+        /**
+         * The clearance height for this tile
+         */
+        readonly zClearance: number;
+
+        /**
+         * Set if the tile will draw supports
+         */
+        readonly hasSupports: boolean;
+
+        /**
+         * Set if the tile allows for drawing supports above this tile
+         */
+        readonly allowSupportsAbove: boolean;
+
+        /**
+         * A tile can be split into 4 sub tiles this defines what of those 4 are occupied by this tile
+         */
+        readonly corners: number;
+
+        /**
+         * Indicates if an edge can have walls built on it
+         */
+        readonly walls: number;
     }
 
     interface WallObject extends SceneryObject {
@@ -2071,7 +2428,7 @@ declare global {
         readonly downtime: number;
 
         /**
-         * The currently set chain lift speed in miles per hour.
+         * The currently set chain lift speed in miles per hour. Use `context.formatString()` to convert speed values to a localised value/unit string. Ex: `formatString('{VELOCITY}', ride.liftHillSpeed)`.
          */
         liftHillSpeed: number;
 
@@ -2084,16 +2441,100 @@ declare global {
          * The min chain lift speed for this ride in miles per hour.
          */
         readonly minLiftHillSpeed: number;
+
+        /**
+         * The satisfaction rating of the ride from 0 to 100.
+         */
+        readonly satisfaction: number;
+
+        /**
+         * The max speed in miles per hour.
+         */
+        readonly maxSpeed: number;
+
+        /**
+         * The average speed in miles per hour.
+         */
+        readonly averageSpeed: number;
+
+        /**
+         * The ride time in seconds.
+         */
+        readonly rideTime: number;
+
+        /**
+         * Total length of the ride in meters. Use `context.formatString()` to convert into localised value/unit string. Ex: `formatString('{LENGTH}', ride.rideLength)`.
+         */
+        readonly rideLength: number;
+
+        /**
+         * The max positive vertical Gs.
+         */
+        readonly maxPositiveVerticalGs: number;
+
+        /**
+         * The max negative vertical Gs.
+         */
+        readonly maxNegativeVerticalGs: number;
+
+        /**
+         * The max lateral Gs.
+         */
+        readonly maxLateralGs: number;
+
+        /**
+         * The total airtime in seconds.
+         */
+        readonly totalAirTime: number;
+
+        /**
+         * The number of drops.
+         */
+        readonly numDrops: number;
+
+        /**
+         * The number of lift hills.
+         */
+        readonly numLiftHills: number;
+
+        /**
+         * Highest drop height in height units. Use `context.formatString()` to convert into metres/feet. Ex: `formatString('{HEIGHT}', ride.highestDropHeight)`.
+         */
+        readonly highestDropHeight: number;
+
+        /**
+        * The current breakdown of the ride.
+        */
+        readonly breakdown: BreakdownType;
+
+        /**
+         * Set a breakdown on a ride.
+         * @param breakdown The type of breakdown to set.
+         */
+        setBreakdown(breakdown: BreakdownType): void;
+
+        /**
+         * Fix a ride / clear the breakdown.
+         */
+        fixBreakdown(): void;
+
     }
 
     type RideClassification = "ride" | "stall" | "facility";
 
     type RideStatus = "closed" | "open" | "testing" | "simulating";
 
+    type BreakdownType = "brakes_failure" | "control_failure" | "doors_stuck_closed" | "doors_stuck_open" | "restraints_stuck_closed" | "restraints_stuck_open" | "safety_cut_out" | "vehicle_malfunction";
+
     interface TrackColour {
         main: number;
         additional: number;
         supports: number;
+    }
+
+    interface CrashedVehicleColour {
+        body: number;
+        trim: number;
     }
 
     interface VehicleColour {
@@ -2141,9 +2582,9 @@ declare global {
         readonly endY: number;
 
         /**
-        * The relative starting direction. Usually 0, but will be 4
-        * for diagonal segments.
-        */
+         * The relative starting direction. Usually 0, but will be 4
+         * for diagonal segments.
+         */
         readonly beginDirection: Direction8;
 
         /**
@@ -2482,6 +2923,11 @@ declare global {
         isReversed: boolean;
 
         /**
+         * Whether to draw the car sprite as a smoke plume.
+         */
+        isCrashed: boolean;
+
+        /**
          * The colour of the car.
          */
         colours: VehicleColour;
@@ -2503,10 +2949,18 @@ declare global {
          */
         status: VehicleStatus;
 
+
+        /**
+         * Current vehicle spin rotation.
+         * Values are 0-255. The game actually only considers the higher
+         * 5 bits when rendering.
+         */
+        spin: number;
+
         /**
          * The location and direction of where the car is on the track.
          */
-        trackLocation: CoordsXYZD;
+        readonly trackLocation: CarTrackLocation;
 
         /**
          * The current g-forces of this car.
@@ -2546,6 +3000,12 @@ declare global {
          * on the direction its moving in.
          */
         travelBy(distance: number): void;
+
+        /**
+         * Moves the vehicle to the track piece specified in the parameters.
+         * Coordinates are tile coords.
+         */
+        moveToTrack(x: number, y: number, elemIndex: number): void;
     }
 
     type VehicleStatus =
@@ -2581,6 +3041,63 @@ declare global {
         "waiting_to_depart" |
         "waiting_to_start";
 
+    type CrashParticleType = "corner" | "rod" | "wheel" | "panel" | "seat";
+
+    /**
+     * Override properties for launch data. All properties except colour are randomly
+     * chosen if not overridden, using the same algorithm as regular crashed particles.
+     */
+    interface CrashParticleLaunchData {
+        colours?: CrashedVehicleColour;
+        timeToLive?: number;
+        velocity?: CoordsXYZ;
+        crashParticleType?: CrashParticleType;
+        frame?: number;
+    }
+
+    /**
+     * Represents a vehicle explosion particle. They are emitted during a vehicle
+     * crash and will bounce until their timer expires and they are automatically
+     * removed.
+     */
+    interface CrashedVehicleParticle extends Entity {
+        /**
+         * The colour of the particle.
+         */
+        colours: CrashedVehicleColour;
+
+        /**
+         * The lifetime of the particle in ticks. Default value 65535. Entity is
+         * automatically removed at 0.
+         */
+        timeToLive: number;
+
+        /**
+         * The particle velocity.
+         */
+        velocity: CoordsXYZ;
+
+        /**
+         * The acceleration of the particle in the x, y, and z directions.
+         */
+        acceleration: CoordsXYZ;
+
+        /**
+         * The type of crash particle.
+         */
+        crashParticleType: CrashParticleType;
+
+        /**
+         * The current frame of the crash particle.
+         */
+        frame: number;
+
+        /**
+         * Sets the sprite bounds and launches the particle.
+         */
+        launch(launchData?: CrashParticleLaunchData): void;
+    }
+
     /**
      * Represents a guest or staff member.
      * @deprecated since version 34, use guest or staff instead.
@@ -2600,6 +3117,11 @@ declare global {
          * The peep's direct destination.
          */
         destination: CoordsXY;
+
+        /**
+         * The peep's orthogonal direction, from 0 to 3.
+         */
+        direction: Direction;
 
         /**
          * How tired the guest is between 32 and 128 where lower is more tired.
@@ -2650,12 +3172,42 @@ declare global {
         "joy" |
         "angry" |
         "iceCream" |
-        "hereWeAre";
+        "hereWeAre" |
+        "positionFrozen" |
+        "animationFrozen";
 
     /**
      * @deprecated since version 34, use EntityType instead.
      */
     type PeepType = "guest" | "staff";
+
+    type GuestAnimation =
+        "walking" |
+        "checkTime" |
+        "watchRide" |
+        "eatFood" |
+        "shakeHead" |
+        "emptyPockets" |
+        "holdMat" |
+        "sittingIdle" |
+        "sittingEatFood" |
+        "sittingLookAroundLeft" |
+        "sittingLookAroundRight" |
+        "hanging" |
+        "wow" |
+        "throwUp" |
+        "jump" |
+        "drowning" |
+        "joy" |
+        "readMap" |
+        "wave" |
+        "wave2" |
+        "takePhoto" |
+        "clap" |
+        "disgust" |
+        "drawPicture" |
+        "beingWatched" |
+        "withdrawMoney";
 
     /**
      * Represents a guest.
@@ -2765,6 +3317,65 @@ declare global {
          * The list of thoughts this guest has.
          */
         readonly thoughts: Thought[];
+
+        /**
+         * The list of items this guest has.
+         */
+        readonly items: GuestItem[];
+
+        /**
+         * Checks whether this guest has a certain item.
+         * @param item The item to check.
+         */
+        hasItem(item: GuestItem): boolean;
+
+        /**
+         * Gives an item to the guest. Guests can only have one item of a given type.
+         * If this guest already has an item of the same type, this will override the current item.
+         * @param item The item to give.
+         */
+        giveItem(item: GuestItem): void;
+
+        /**
+         * Removes an item from the guest's possession.
+         * @param item The item to remove.
+         */
+        removeItem(item: GuestItem): void;
+
+        /**
+         * Removes all items from the guest's possession.
+         */
+        removeAllItems(): void;
+
+        /**
+         * The animations available to this guest.
+         */
+        readonly availableAnimations: GuestAnimation[];
+
+        /**
+         * Gets an array of sprite ids representing a particular guest animation.
+         */
+        getAnimationSpriteIds(animation: GuestAnimation, rotation: number): number[];
+
+        /**
+         * The animation the guest is currently exhibiting.
+         */
+        animation: GuestAnimation;
+
+        /**
+         * The frame offset in the current animation.
+         */
+        animationOffset: number;
+
+        /**
+         * The total number of frames in the current animation.
+         */
+        readonly animationLength: number;
+
+        /**
+         * The ride ID of the guest's favourite ride.
+         */
+        favouriteRide: number | null;
     }
 
     /**
@@ -2927,24 +3538,181 @@ declare global {
         "excited_deprecated" |
         "here_we_are";
 
+    type GuestItemType =
+        "balloon" |
+        "hat" |
+        "map" |
+        "sunglasses" |
+        "toy" |
+        "tshirt" |
+        "umbrella" |
+        "photo1" |
+        "photo2" |
+        "photo3" |
+        "photo4" |
+        "voucher" |
+        "beef_noodles" |
+        "burger" |
+        "candyfloss" |
+        "chicken" |
+        "chips" |
+        "chocolate" |
+        "cookie" |
+        "doughnut" |
+        "hot_dog" |
+        "fried_rice_noodles" |
+        "funnel_cake" |
+        "ice_cream" |
+        "meatball_soup" |
+        "pizza" |
+        "popcorn" |
+        "pretzel" |
+        "roast_sausage" |
+        "sub_sandwich" |
+        "tentacle" |
+        "toffee_apple" |
+        "wonton_soup" |
+        "coffee" |
+        "drink" |
+        "fruit_juice" |
+        "iced_tea" |
+        "lemonade" |
+        "soybean_milk" |
+        "sujeonggwa" |
+        "empty_bottle" |
+        "empty_bowl_blue" |
+        "empty_bowl_red" |
+        "empty_box" |
+        "empty_burger_box" |
+        "empty_can" |
+        "empty_cup" |
+        "empty_drink_carton" |
+        "empty_juice_cup" |
+        "rubbish";
+
+    type VoucherType =
+        "entry_free" |
+        "entry_half_price" |
+        "ride_free" |
+        "food_drink_free";
+
+    /**
+     * Represents an item in a guest's possession.
+     * If giving a guest a photo or voucher, use the other interfaces instead.
+     */
+    interface GuestItem {
+        /**
+         * The type of item.
+         */
+        readonly type: GuestItemType;
+    }
+
+    /**
+     * Represents an on-ride photo in a guest's possession.
+     */
+    interface GuestPhoto extends GuestItem {
+        readonly type: "photo1" | "photo2" | "photo3" | "photo4";
+        /**
+         * The id of the ride the on-ride photo is for.
+         */
+        readonly rideId: number;
+    }
+
+    /**
+     * Represents a voucher in a guest's possession. If giving a guest a voucher for free rides
+     * or free food/drink, use the other interfaces instead.
+     */
+    interface Voucher extends GuestItem {
+        readonly type: "voucher";
+        /**
+         * The type of voucher.
+         */
+        readonly voucherType: VoucherType;
+    }
+
+    /**
+     * Represents a voucher for a free ride in a guest's possession.
+     */
+    interface RideVoucher extends Voucher {
+        readonly voucherType: "ride_free";
+        /**
+         * The id of the ride the voucher is for.
+         */
+        readonly rideId: number;
+    }
+
+    /**
+     * Represents a voucher for free food or drink in a guest's possession.
+     */
+    interface FoodDrinkVoucher extends Voucher {
+        readonly voucherType: "food_drink_free";
+        /**
+         * The type of food or drink the voucher is for.
+         */
+        readonly item: GuestItemType;
+    }
+
+    type StaffCostume =
+        "none" |
+        "handyman" |
+        "mechanic" |
+        "security1" |
+        "security2" |
+        "panda" |
+        "tiger" |
+        "elephant" |
+        "roman" |
+        "gorilla" |
+        "snowman" |
+        "knight" |
+        "astronaut" |
+        "bandit" |
+        "sheriff" |
+        "pirate";
+
+    type StaffAnimation =
+        "walking" |
+        "watchRide" |
+        "wave" |
+        "hanging" |
+        "staffMower" |
+        "staffSweep" |
+        "drowning" |
+        "staffAnswerCall" |
+        "staffAnswerCall2" |
+        "staffCheckBoard" |
+        "staffFix" |
+        "staffFix2" |
+        "staffFixGround" |
+        "staffFix3" |
+        "staffWatering" |
+        "joy" |
+        "staffEmptyBin" |
+        "wave2";
+
     /**
      * Represents a staff member.
      */
-    interface Staff extends Peep {
+    interface BaseStaff extends Peep {
         /**
          * The type of staff member, e.g. handyman, mechanic.
          */
         staffType: StaffType;
 
         /**
-         * Colour of the staff member. Not applicable for entertainers.
+         * Colour of the staff member. Not applicable to entertainers.
          */
         colour: number;
 
         /**
-         * The entertainer's costume, only applicable for entertainers.
+         * Array of costumes available to this particular staff member.
          */
-        costume: number;
+        readonly availableCostumes: StaffCostume[];
+
+        /**
+         * The staff member's costume.
+         */
+        costume: StaffCostume | string | number;
 
         /**
          * The enabled jobs the staff can do, e.g. sweep litter, water plants, inspect rides etc.
@@ -2955,9 +3723,96 @@ declare global {
          * Gets the patrol area for the staff member.
          */
         readonly patrolArea: PatrolArea;
+
+        /**
+         * The animations available to this staff member.
+         */
+        readonly availableAnimations: StaffAnimation[];
+
+        /**
+         * Gets an array of sprite ids representing a particular staff animation.
+         */
+        getAnimationSpriteIds(animation: StaffAnimation, rotation: number): number[];
+
+        /**
+         * The animation the staff member is currently exhibiting.
+         */
+        animation: StaffAnimation;
+
+        /**
+         * The frame offset in the current animation.
+         */
+        animationOffset: number;
+
+        /**
+         * The total number of frames in the current animation.
+         */
+        readonly animationLength: number;
     }
 
     type StaffType = "handyman" | "mechanic" | "security" | "entertainer";
+
+    type Staff = Handyman | Mechanic | Security | Entertainer;
+
+    /**
+     * Represents a handyman.
+     */
+    interface Handyman extends BaseStaff {
+        staffType: "handyman";
+
+        /**
+         * The number of lawns mown by the handyman.
+         */
+        readonly lawnsMown: number;
+
+        /**
+         * The number of gardens watered by the handyman.
+         */
+        readonly gardensWatered: number;
+
+        /**
+         * The number of litter swept by the handyman.
+         */
+        readonly litterSwept: number;
+
+        /**
+         * The number of bins emptied by the handyman.
+         */
+        readonly binsEmptied: number;
+    }
+
+    /**
+     * Represents a mechanic.
+     */
+    interface Mechanic extends BaseStaff {
+        staffType: "mechanic";
+
+        /**
+         * The number of rides fixed by the mechanic.
+         */
+        readonly ridesFixed: number;
+
+        /**
+         * The number of inspections performed by the mechanic.
+         */
+        readonly ridesInspected: number;
+    }
+
+    /**
+     * Represents a security guard.
+     */
+    interface Security extends BaseStaff {
+        staffType: "security";
+
+        /**
+         * The number of vandals stopped by the security guard.
+         */
+        readonly vandalsStopped: number;
+    }
+
+    interface Entertainer extends BaseStaff {
+        staffType: "entertainer";
+    }
 
     interface PatrolArea {
         /**
@@ -3018,6 +3873,26 @@ declare global {
         "empty_drink_carton" |
         "empty_juice_cup" |
         "empty_bowl_blue";
+
+    /**
+     * Represents balloon entity.
+     */
+    interface Balloon extends Entity {
+        /**
+         * The colour of the balloon.
+         */
+        colour: number;
+    }
+
+    /**
+     * Represents money_effect entity.
+     */
+    interface MoneyEffect extends Entity {
+        /**
+         * The value of the money effect.
+         */
+        value: number;
+    }
 
     /**
      * Network APIs
@@ -3304,6 +4179,53 @@ declare global {
         "scenarioCompleteNameInput" |
         "unlockAllPrices";
 
+    type AwardType =
+        "mostUntidy" |
+        "mostTidy" |
+        "bestRollerCoasters" |
+        "bestValue" |
+        "mostBeautiful" |
+        "worstValue" |
+        "safest" |
+        "bestStaff" |
+        "bestFood" |
+        "worstFood" |
+        "bestToilets" |
+        "mostDisappointing" |
+        "bestWaterRides" |
+        "bestCustomDesignedRides" |
+        "mostDazzlingRideColours" |
+        "mostConfusingLayout" |
+        "bestGentleRides";
+
+    interface Award {
+        /**
+         * The type of the award.
+         */
+        readonly type: AwardType;
+
+        /**
+         * The award description.
+         */
+        readonly text: string;
+
+        /**
+         * Number of months this award will remain active.
+         * Starts at 5, expires at 0.
+         */
+        readonly monthsRemaining: number;
+
+        /**
+         * The sprite of the award.
+         */
+        readonly imageId: number;
+
+        /**
+         * Whether this is a positive or negative award.
+         */
+        readonly positive: boolean;
+    }
+
     interface Park {
         cash: number;
         rating: number;
@@ -3334,6 +4256,12 @@ declare global {
          * guests per second = 40 * (guestGenerationProbability / 65535)
          */
         readonly guestGenerationProbability: number;
+
+        /**
+         * Spawns a new guest at a random peep spawn point.
+         * Note: The "guest.generation" hook will be called before this function returns.
+         */
+        generateGuest(): Guest;
 
         /**
          * The average amount of cash guests will spawn with.
@@ -3437,6 +4365,33 @@ declare global {
 
         postMessage(message: string): void;
         postMessage(message: ParkMessageDesc): void;
+
+        /**
+         * Gets the monthly expenditure history for a given type.
+         * Index 0 represents the current month, index 1 the previous month, etc.
+         * The maximum length of the array is 16.
+         * @param type The type of expenditure to get.
+         */
+        getMonthlyExpenditure(type: ExpenditureType): number[]
+
+        /**
+         * The current awards of the park.
+         */
+        readonly awards: Award[]
+
+        /**
+         *  Clear all awards.
+         */
+        clearAwards(): void
+
+        /**
+         * Grant the given award type to the park.
+         * Does not check eligibility.
+         * If the park already has an active award of the given type, the old award will be removed.
+         * If the park already has 4 active awards, the oldest award will be removed.
+         * @param type the award type to grant
+         */
+        grantAward(type: AwardType): void
     }
 
     interface Research {
@@ -3464,8 +4419,9 @@ declare global {
 
         /**
          * The amount of funding currently spent on research.
+         * 0: none, 1: minimum, 2: normal, 3: maximum
          */
-        funding: ResearchFundingLevel;
+        funding: number;
 
         /**
          * The categories of research which should be prioritised.
@@ -3515,10 +4471,10 @@ declare global {
          * E.g. gentle rides, thrill rides, shops etc.
          * Note: Any updates to this field are ignored by OpenRCT2, the category will be derived from the ride type.
          */
-        readonly category?: ResearchCategory;
+        readonly category: RideResearchCategory;
 
         /**
-         * The ride type. Each vehicle can have a seperate invention for each ride type.
+         * The ride type. Each vehicle can have a separate invention for each ride type.
          */
         readonly rideType: number;
 
@@ -3529,7 +4485,7 @@ declare global {
     }
 
     interface SceneryResearchItem {
-        readonly category?: "scenery_group";
+        readonly category: "scenery";
         readonly type: "scenery";
 
         /**
@@ -3538,23 +4494,15 @@ declare global {
         readonly object: number;
     }
 
-    type ResearchItemType = "scenery" | "ride";
-
-    type ResearchCategory =
+    type RideResearchCategory =
         "transport" |
         "gentle" |
         "rollercoaster" |
         "thrill" |
         "water" |
-        "shop" |
-        "scenery";
+        "shop";
 
-    enum ResearchFundingLevel {
-        None,
-        Minimum,
-        Normal,
-        Maximum
-    }
+    type ResearchCategory = RideResearchCategory | "scenery";
 
     type ResearchFundingStage =
         "initial_research" |
@@ -3683,7 +4631,7 @@ declare global {
         "heavySnow" |
         "blizzard";
 
-    interface ClimateState {
+    interface WeatherState {
         readonly weather: WeatherType;
         readonly temperature: number;
     }
@@ -3697,16 +4645,17 @@ declare global {
         /**
          * The current weather in the park.
          */
-        readonly current: ClimateState;
+        readonly current: WeatherState;
 
         /**
          * The next weather the park will experience.
          */
-        readonly future: ClimateState;
+        readonly future: WeatherState;
     }
 
     interface Cheats {
         allowArbitraryRideTypeChanges: boolean;
+        allowSpecialColourSchemes: boolean;
         allowTrackPlaceInvalidHeights: boolean;
         buildInPauseMode: boolean;
         disableAllBreakdowns: boolean;
@@ -3721,10 +4670,13 @@ declare global {
         enableAllDrawableTrackPieces: boolean;
         enableChainLiftOnAllTrack: boolean;
         fastLiftHill: boolean;
+        forcedParkRating: number;
         freezeWeather: boolean;
         ignoreResearchStatus: boolean;
         ignoreRideIntensity: boolean;
+        ignoreRidePrice: boolean;
         neverendingMarketing: boolean;
+        makeAllDestructible: boolean;
         sandboxMode: boolean;
         showAllOperatingModes: boolean;
         showVehiclesFromOtherTrackTypes: boolean;
@@ -3895,7 +4847,7 @@ declare global {
     interface ToolEventArgs {
         readonly isDown: boolean;
         readonly screenCoords: ScreenCoordsXY;
-        readonly mapCoords?: CoordsXYZ;
+        readonly mapCoords?: CoordsXY;
         readonly tileElementIndex?: number;
         readonly entityId?: number;
     }
@@ -3999,25 +4951,29 @@ declare global {
         ButtonWidget | CheckboxWidget | ColourPickerWidget | CustomWidget | DropdownWidget | GroupBoxWidget |
         LabelWidget | ListViewWidget | SpinnerWidget | TextBoxWidget | ViewportWidget;
 
-    type IconName = "arrow_down" | "arrow_up" | "chat" | "cheats" | "copy" | "empty" | "eyedropper" |
-        "fast_forward" | "game_speed_indicator" | "game_speed_indicator_double" | "glassy_recolourable" |
-        "hide_full" | "hide_partial" | "hide_scenery" | "hide_supports" | "hide_vegetation" | "hide_vehicles" |
-        "large_scenery" | "legacy_paths" | "link_chain" | "logo" | "logo_text" | "map_east" |
-        "map_east_pressed" | "map_gen_land" | "map_gen_noise" | "map_gen_trees" | "map_north" |
-        "map_north_pressed" | "map_south" | "map_south_pressed" | "map_west" | "map_west_pressed" |
+    type IconName =
+        "arrow_down" | "arrow_up" | "award" | "awards" | "chain_lift" | "chat" | "cheats" | "closed" | "construction" |
+        "copy" | "demolish" | "empty" | "eyedropper" | "fast_forward" | "finance" | "floppy_disk" | "game_speed_indicator" |
+        "game_speed_indicator_double" | "glassy_recolourable" | "graph" | "guest_inventory" | "guests" |
+        "hearing" | "hide_full" | "hide_partial" | "hide_scenery" | "hide_supports" | "hide_vegetation" | "hide_vehicles" |
+        "kiosks_and_facilities" | "large_scenery" | "legacy_paths" | "link_chain" | "locate" | "logo" | "logo_text" | "map" |
+        "map_east" | "map_east_pressed" | "map_gen_land" | "map_gen_noise" | "map_gen_trees" | "map_north" | "map_north_pressed" |
+        "map_south" | "map_south_pressed" | "map_west" | "map_west_pressed" | "mechanic" | "mirror_arrow" |
         "mountain_tool_even" | "mountain_tool_odd" | "multiplayer" | "multiplayer_desync" | "multiplayer_sync" |
-        "multiplayer_toolbar" | "multiplayer_toolbar_pressed" | "mute" | "mute_pressed" | "news_messages" |
-        "normal_selection_6x6" | "palette_invisible" | "palette_invisible_pressed" | "paste" | "path_railings" | "path_surfaces" | "paths" | "placeholder" |
-        "rct1_close_off" | "rct1_close_off_pressed" | "rct1_close_on" | "rct1_close_on_pressed" | "rct1_open_off" |
-        "rct1_open_off_pressed" | "rct1_open_on" | "rct1_open_on_pressed" | "rct1_simulate_off" |
-        "rct1_simulate_off_pressed" | "rct1_simulate_on" | "rct1_simulate_on_pressed" | "rct1_test_off" |
-        "rct1_test_off_pressed" | "rct1_test_on" | "rct1_test_on_pressed" | "reload" | "ride_stations" |
-        "scenery_scatter_high" | "scenery_scatter_low" | "scenery_scatter_medium" | "search" |
-        "selection_edge_ne" | "selection_edge_nw" | "selection_edge_se" | "selection_edge_sw" |
-        "server_password" | "sideways_tab" | "sideways_tab_active" | "simulate" | "small_scenery" | "sort" |
-        "terrain_edges" | "title_play" | "title_restart" | "title_skip" | "title_stop" | "unmute" |
-        "unmute_pressed" | "view" | "zoom_in" | "zoom_in_background" | "zoom_out" | "zoom_out_background";
-
+        "multiplayer_toolbar" | "multiplayer_toolbar_pressed" | "music" | "mute" | "mute_pressed" | "news_messages" |
+        "new_ride" | "next" | "no_entry" | "open" | "paintbrush" | "palette_invisible" | "palette_invisible_pressed" | "park" |
+        "paste" | "path_railings" | "path_surfaces" | "paths" | "patrol" | "pause" | "pickup" | "placeholder" | "previous" |
+        "question" | "rct1_close_off" | "rct1_close_off_pressed" | "rct1_close_on" | "rct1_close_on_pressed" | "rct1_open_off" |
+        "rct1_open_off_pressed" | "rct1_open_on" | "rct1_open_on_pressed" | "rct1_simulate_off" | "rct1_simulate_off_pressed" |
+        "rct1_simulate_on" | "rct1_simulate_on_pressed" | "rct1_test_off" | "rct1_test_off_pressed" | "rct1_test_on" |
+        "rct1_test_on_pressed" | "reload" | "rename" | "research" | "ride" | "ride_stations" | "rides_gentle" |
+        "rides_rollercoasters" | "rides_shop" | "rides_thrill" | "rides_transport" | "rides_water" | "rotate_arrow" | "scenery" |
+        "scenery_cluster" | "scenery_paths" | "scenery_paths_items" | "scenery_scatter_high" | "scenery_scatter_low" |
+        "scenery_scatter_medium" | "scenery_signage" | "scenery_statues" | "scenery_trees" | "scenery_urban" | "scenery_walls" |
+        "search" | "selection_edge_ne" | "selection_edge_nw" | "selection_edge_se" | "selection_edge_sw" | "server_password" |
+        "shops_and_stalls" | "sideways_tab" | "sideways_tab_active" | "simulate" | "small_scenery" | "sort" | "stats" | "testing" |
+        "terrain_edges" | "title_play" | "title_restart" | "title_skip" | "title_stop" | "unmute" | "unmute_pressed" | "view" |
+        "water" | "zoom_in" | "zoom_in_background" | "zoom_out" | "zoom_out_background";
 
     interface WidgetBase {
         readonly window: Window;
@@ -4100,7 +5056,7 @@ declare global {
         column: number;
     }
 
-    type ListViewItem = ListViewItemSeperator | string[] | string;
+    type ListViewItem = ListViewItemSeparator | string[] | string;
 
     interface ListViewWidget extends WidgetBase {
         type: "listview";
@@ -4123,6 +5079,7 @@ declare global {
         type: "textbox";
         text: string;
         maxLength: number;
+        focus(): void;
     }
 
     interface ViewportWidget extends WidgetBase {
@@ -4226,8 +5183,8 @@ declare global {
         textAlign?: TextAlignment;
     }
 
-    interface ListViewItemSeperator {
-        type: "seperator";
+    interface ListViewItemSeparator {
+        type: "separator";
         text?: string;
     }
 
@@ -4302,6 +5259,9 @@ declare global {
         frameBase: number;
         frameCount?: number;
         frameDuration?: number;
+        primaryColour?: number;
+        secondaryColour?: number;
+        tertiaryColour?: number;
         offset?: ScreenCoordsXY;
     }
 
@@ -4787,7 +5747,6 @@ declare global {
         getObject(type: "footpath_addition", index: number): FootpathAdditionObject;
         getObject(type: "banner", index: number): BannerObject;
         getObject(type: "scenery_group", index: number): SceneryGroupObject;
-        getObject(type: "music", index: number): LoadedObject;
 
         /**
          * Gets all the currently loaded objects for a given object type.
@@ -4801,6 +5760,12 @@ declare global {
         getAllObjects(type: "footpath_addition"): FootpathAdditionObject[];
         getAllObjects(type: "banner"): BannerObject[];
         getAllObjects(type: "scenery_group"): SceneryGroupObject[];
-        getAllObjects(type: "music"): LoadedObject[];
+    }
+
+    /**
+     * Interface to handle the plugin manager
+     */
+    interface PluginManager {
+        readonly plugins: PluginMetadata[];
     }
 }

--- a/src/entityViewer.ts
+++ b/src/entityViewer.ts
@@ -92,7 +92,7 @@ namespace EntityViewer {
                 return;
             }
 
-            const sep = (text: string) => <ListViewItemSeperator>{ type: 'seperator', text };
+            const sep = (text: string) => <ListViewItemSeparator>{ type: 'separator', text };
 
             let data: ListViewItem[] = [
                 sep('Entity'),


### PR DESCRIPTION
**What** - update openrct2 typescript type reference to up-to date version, fix spelling of _seperator_ to _separator_

**Why** - follow up to 
- OpenRCT2/OpenRCT2#25041

so all _seperators_ are obliterated from this project for good!

________

I hereby solemnly swear I have tried to build and successfully build-ed version provided in this PR and I have tested that it works in current release and dev version of the OpenRCT2